### PR TITLE
removed validate_no_state() in favor of new params added to validate(); added flags to allow for self signed certs in the jwt validation method

### DIFF
--- a/src/lti/LTI_Message_Launch.php
+++ b/src/lti/LTI_Message_Launch.php
@@ -222,7 +222,7 @@ class LTI_Message_Launch
 
         // Download key set
         $public_key_set = json_decode(
-            file_get_contents(
+            @file_get_contents(
                 $key_set_url,
                 false,
                 stream_context_create([


### PR DESCRIPTION
more tweaks to the validation process, this time to support self-signed certs for the LMS in non-production regions.