### PR TITLE
updated validate methods to allow missing 'sub' launch param when an …

### DIFF
--- a/src/lti/message_validators/deep_link_message_validator.php
+++ b/src/lti/message_validators/deep_link_message_validator.php
@@ -7,14 +7,15 @@ class Deep_Link_Message_Validator implements Message_Validator {
     }
 
     public function validate($jwt_body) {
-        if (empty($jwt_body['sub'])) {
-            throw new LTI_Exception('Must have a user (sub)');
-        }
         if ($jwt_body['https://purl.imsglobal.org/spec/lti/claim/version'] !== '1.3.0') {
             throw new LTI_Exception('Incorrect version, expected 1.3.0');
         }
         if (!isset($jwt_body['https://purl.imsglobal.org/spec/lti/claim/roles'])) {
             throw new LTI_Exception('Missing Roles Claim');
+        }
+        # allow missing sub only for anonymous launches per https://www.imsglobal.org/spec/lti/v1p3#user-identity-claims
+        if (empty($jwt_body['sub']) && !in_array('http://purl.imsglobal.org/vocab/lis/v2/system/person#None',$jwt_body['https://purl.imsglobal.org/spec/lti/claim/roles'])) {
+            throw new LTI_Exception('Must have a user (sub)');
         }
         if (empty($jwt_body['https://purl.imsglobal.org/spec/lti-dl/claim/deep_linking_settings'])) {
             throw new LTI_Exception('Missing Deep Linking Settings');

--- a/src/lti/message_validators/resource_message_validator.php
+++ b/src/lti/message_validators/resource_message_validator.php
@@ -10,9 +10,6 @@ class Resource_Message_Validator implements Message_Validator
 
     public function validate($jwt_body)
     {
-        if (empty($jwt_body['sub'])) {
-            throw new LTI_Exception('Must have a user (sub)');
-        }
         if (!isset($jwt_body['https://purl.imsglobal.org/spec/lti/claim/version'])) {
             throw new LTI_Exception('Missing Version Claim');
         }
@@ -21,6 +18,11 @@ class Resource_Message_Validator implements Message_Validator
         }
         if (!isset($jwt_body['https://purl.imsglobal.org/spec/lti/claim/roles'])) {
             throw new LTI_Exception('Missing Roles Claim');
+        }
+        # allow missing sub only for anonymous launches per https://www.imsglobal.org/spec/lti/v1p3#user-identity-claims
+        if (empty($jwt_body['sub']) && !in_array('http://purl.imsglobal.org/vocab/lis/v2/system/person#None',$jwt_body['https://purl.imsglobal.org/spec/lti/claim/roles'])) {
+            die($jwt_body['https://purl.imsglobal.org/spec/lti/claim/roles']);
+            throw new LTI_Exception('Must have a user (sub)');
         }
         if (empty($jwt_body['https://purl.imsglobal.org/spec/lti/claim/resource_link']['id'])) {
             throw new LTI_Exception('Missing Resource Link Id');

--- a/src/lti/message_validators/resource_message_validator.php
+++ b/src/lti/message_validators/resource_message_validator.php
@@ -21,7 +21,6 @@ class Resource_Message_Validator implements Message_Validator
         }
         # allow missing sub only for anonymous launches per https://www.imsglobal.org/spec/lti/v1p3#user-identity-claims
         if (empty($jwt_body['sub']) && !in_array('http://purl.imsglobal.org/vocab/lis/v2/system/person#None',$jwt_body['https://purl.imsglobal.org/spec/lti/claim/roles'])) {
-            die($jwt_body['https://purl.imsglobal.org/spec/lti/claim/roles']);
             throw new LTI_Exception('Must have a user (sub)');
         }
         if (empty($jwt_body['https://purl.imsglobal.org/spec/lti/claim/resource_link']['id'])) {

--- a/src/lti/message_validators/submission_review_message_validator.php
+++ b/src/lti/message_validators/submission_review_message_validator.php
@@ -7,14 +7,15 @@ class Submission_Review_Message_Validator implements Message_Validator {
     }
 
     public function validate($jwt_body) {
-        if (empty($jwt_body['sub'])) {
-            throw new LTI_Exception('Must have a user (sub)');
-        }
         if ($jwt_body['https://purl.imsglobal.org/spec/lti/claim/version'] !== '1.3.0') {
             throw new LTI_Exception('Incorrect version, expected 1.3.0');
         }
         if (!isset($jwt_body['https://purl.imsglobal.org/spec/lti/claim/roles'])) {
             throw new LTI_Exception('Missing Roles Claim');
+        }
+        # allow missing sub only for anonymous launches per https://www.imsglobal.org/spec/lti/v1p3#user-identity-claims
+        if (empty($jwt_body['sub']) && !in_array('http://purl.imsglobal.org/vocab/lis/v2/system/person#None',$jwt_body['https://purl.imsglobal.org/spec/lti/claim/roles'])) {
+            throw new LTI_Exception('Must have a user (sub)');
         }
         if (empty($jwt_body['https://purl.imsglobal.org/spec/lti/claim/resource_link']['id'])) {
             throw new LTI_Exception('Missing Resource Link Id');


### PR DESCRIPTION
…anonymous launch is detected